### PR TITLE
永続化ボリュームの設定

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -50,3 +50,8 @@ ssh:
 <% ENV.fetch('DEPLOY_SSH_KEYS').split(',').each do |key| %>
     - <%= key.strip %>
 <% end %>
+
+<% if ENV['DEPLOY_VOLUMES_STORAGE'].present? %>
+volumes:
+  - "<%= ENV['DEPLOY_VOLUMES_STORAGE'] %>:/rails/storage"
+<% end %>

--- a/dot.env.production.sample
+++ b/dot.env.production.sample
@@ -34,6 +34,12 @@ DEPLOY_SSH_PORT=2222
 DEPLOY_SSH_USER=yourname
 DEPLOY_SSH_KEYS="/Users/yourname/.ssh/rsa_id_rsa"
 
+# Host directory to mount into the container for data persistence.
+# If not specified, data will not be persisted and will be lost when the container is restarted.
+# For demo purposes, leaving this unset is usually fine.
+# If you specify a directory, make sure to create it on the host before deploying.
+DEPLOY_VOLUMES_STORAGE=/home/yourname/unified-flash-messages-storage
+
 # The deployment host for kamal-proxy.
 # This must match the Common Name (CN) of your custom TLS certificate.
 DEPLOY_PROXY_HOST=staging.example.com

--- a/dot.env.staging.sample
+++ b/dot.env.staging.sample
@@ -34,6 +34,12 @@ DEPLOY_SSH_PORT=2222
 DEPLOY_SSH_USER=yourname
 DEPLOY_SSH_KEYS="/Users/yourname/.ssh/rsa_id_rsa"
 
+# Host directory to mount into the container for data persistence.
+# If not specified, data will not be persisted and will be lost when the container is restarted.
+# For demo purposes, leaving this unset is usually fine.
+# If you specify a directory, make sure to create it on the host before deploying.
+DEPLOY_VOLUMES_STORAGE=/home/yourname/unified-flash-messages-storage
+
 # The deployment host for kamal-proxy.
 # This must match the Common Name (CN) of your custom TLS certificate.
 DEPLOY_PROXY_HOST=staging.example.com


### PR DESCRIPTION
このアプリは単なるフラッシュメッセージのデモ用なので、永続化ボリュームについては不要と判断して作らないようにしていましたが、設定によって作るようにします。

環境変数 `DEPLOY_VOLUMES_STORAGE` にパスが指定してある場合は、そのディレクトリをコンテナにマウントするようにします。このディレクトリはデプロイ前に作成しておく必要があります。さもないと、 root 所有で作成されるため、サーバの起動時にエラーになり、起動できません。（サーバはユーザ rails で実行されるためストレージの書き込みができない= DBを作成できない）

-----

This pull request adds support for mounting a persistent storage volume for Rails file storage during deployment, and updates the sample environment files to document and demonstrate this new option.

Deployment configuration improvements:

* [`config/deploy.yml`](diffhunk://#diff-fa61612ba96bd682e6fcf1734a4558f3569972a070a4fe902b85972a485b6a36R53-R57): Adds logic to include a `volumes` section if the `DEPLOY_VOLUMES_STORAGE` environment variable is set, mounting the specified host directory to `/rails/storage` in the container.

Documentation and sample environment updates:

* `dot.env.production.sample`, `dot.env.staging.sample`: Add and document the `DEPLOY_VOLUMES_STORAGE` variable, explaining its purpose for data persistence and providing an example path. [[1]](diffhunk://#diff-ef5574e1fb36a662e19a2854820333bad07dee59be39d0fa77306925c776e327R37-R42) [[2]](diffhunk://#diff-7280b4f46db006dbd39a2c67956acfb186c336924de1539612ef92e510112cd2R37-R42)